### PR TITLE
Fix audio merging when segment doesn't start with a sync byte.

### DIFF
--- a/src/hls.h
+++ b/src/hls.h
@@ -94,6 +94,8 @@ int get_playlist_type(char *source);
 int handle_hls_master_playlist(struct hls_master_playlist *ma);
 int handle_hls_media_playlist(hls_media_playlist_t *me);
 int download_live_hls(write_ctx_t *ctx, hls_media_playlist_t *me);
+bool consecutive_sync_byte(uint8_t *buf, size_t len, uint8_t n);
+uint8_t * find_first_ts_packet(ByteBuffer_t *buf);
 int download_hls(write_ctx_t *ctx, hls_media_playlist_t *me, hls_media_playlist_t *me_audio);
 int print_enc_keys(hls_media_playlist_t *me);
 void print_hls_master_playlist(struct hls_master_playlist *ma);


### PR DESCRIPTION
Fixes #53

---

Not sure my heuristic is the best, but I don't see how to do it differently. Let me know if you think it could be improved one way or another (e.g. looking for more than 3 consecutive sync bytes, calculating some checksums, etc…). By the way, my C is a bit rusted. Pardon me if I've made clumsy mistakes and please review carefully.

Also, I think the `hls_download` function leaks memory when the audio segment ends before the video segment. The video segment is never freed in such case. This was not introduced by this PR.