### PR TITLE
add option for selecting the audio language

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -132,6 +132,7 @@ int main(int argc, char *argv[])
     hls_args.refresh_delay_sec = -1;
     hls_args.maxwidth = -1;
     hls_args.maxheight = -1;
+    hls_args.audiolang = NULL;
 
     if (parse_argv(argc, argv)) {
         MSG_WARNING("No files passed. Exiting.\n");
@@ -263,8 +264,28 @@ int main(int argc, char *argv[])
                 int i = 1;
 
                 if (!selected_audio) {
-                    if (!hls_args.use_best) {
+                    if (hls_args.use_best || hls_args.audiolang) {
+                        i = 0;
                         audio = master_playlist.audio;
+                        while (audio) {
+                            if (0 == strcmp(audio->grp_id, selected->audio_grp)) {
+                                i += 1;
+                                if (hls_args.use_best && audio->is_default) {
+                                    audio_choice = i;
+                                    break;
+                                }
+                                if (hls_args.audiolang && audio->lang && 0 == strcmp(audio->lang, hls_args.audiolang)) {
+                                    audio_choice = i;
+                                    break;
+                                }
+                            }
+                            audio = audio->next;
+                        }
+                    }
+
+                    if (audio_choice == 0) {
+                        audio = master_playlist.audio;
+                        i = 0;
                         while (audio) {
                             if (0 == strcmp(audio->grp_id, selected->audio_grp)) {
                                 MSG_PRINT("%d: Name: %s, Language: %s\n", i, audio->name, audio->lang ? audio->lang : "unknown");
@@ -277,18 +298,6 @@ int main(int argc, char *argv[])
                         if (scanf("%d", &audio_choice) != 1 || audio_choice <= 0 || audio_choice >= i) {
                             MSG_ERROR("Wrong input!\n");
                             exit(1);
-                        }
-                    } else {
-                        audio_choice = 1;
-                        i = 0;
-                        audio = master_playlist.audio;
-                        while (audio) {
-                            if (0 == strcmp(audio->grp_id, selected->audio_grp) && audio->is_default) {
-                                i += 1;
-                                audio_choice = i;
-                                break;
-                            }
-                            audio = audio->next;
                         }
                     }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -25,6 +25,7 @@ static void print_help(const char *filename)
            "-b ... Automatically choose the best quality.\n"
            "-W ... Choose largest width lower or equal than this.\n"
            "-H ... Choose largest height lower or equal than this.\n"
+           "-A ... Select audio language.\n"
            "-v ... Verbose more information.\n"
            "-o ... Choose name of output file (\"-\" alias for stdout).\n"
            "-u ... Set custom HTTP User-Agent header.\n"
@@ -53,7 +54,7 @@ int parse_argv(int argc, char * const argv[])
     int ret = 0;
     int c = 0;
     int custom_header_idx = 0;
-    while ( (c = getopt(argc, argv, "bH:W:vqbfFK:ctdo:u:h:s:r:w:e:p:k:n:a:C:")) != -1)
+    while ( (c = getopt(argc, argv, "bH:W:A:vqbfFK:ctdo:u:h:s:r:w:e:p:k:n:a:C:")) != -1)
     {
         switch (c)
         {
@@ -71,6 +72,9 @@ int parse_argv(int argc, char * const argv[])
             break;
         case 'H':
             hls_args.maxheight = atoi(optarg);
+            break;
+        case 'A':
+            hls_args.audiolang = optarg;
             break;
         case 'h':
             if (custom_header_idx < HLSDL_MAX_NUM_OF_CUSTOM_HEADERS) {

--- a/src/misc.h
+++ b/src/misc.h
@@ -31,6 +31,7 @@ struct hls_args {
     bool use_best;
     int maxwidth;
     int maxheight;
+    char *audiolang;
     int skip_encryption;
     bool force_overwrite;
     bool force_ignoredrm;


### PR DESCRIPTION
The new option allows to choose the language on the command line.
For example, ``hlsdl -A eng url`` selects the english language if present without asking the user.