### PR TITLE
downloading duration et al

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Usage and Options
 ```
 -b ... Automatically choose the best quality.
 
+-W ... Choose largest width lower or equal than this.
+
+-H ... Choose largest height lower or equal than this.
+
+-A ... Select audio language.
+
 -v ... Verbose more information.
 
 -o ... Choose name of output file ("-" alias for stdout).
@@ -55,6 +61,8 @@ Usage and Options
 -t ... Print the links to the .ts files.
 
 -s ... Set live start offset in seconds.
+
+-i ... Set live stream download duration in seconds.
 
 -e ... Set refresh delay in seconds.
 

--- a/makefile
+++ b/makefile
@@ -35,7 +35,9 @@ else
 endif
 
 
-all: $(S_OBJS)
+all: $(HLSDL)
+
+hlsdl: $(S_OBJS)
 	$(CC) $(S_OBJS) $(LDFLAGS) -o $(HLSDL)
 
 install:

--- a/src/hls.c
+++ b/src/hls.c
@@ -1416,6 +1416,11 @@ int download_live_hls(write_ctx_t *out_ctx, hls_media_playlist_t *me)
             }
 
             downloaded_duration_ms += ms->duration_ms;
+            if (hls_args.live_duration_sec > 0 && downloaded_duration_ms > hls_args.live_duration_sec * 1000) {
+                download = false;
+                pthread_cancel(thread);
+                break;
+            }
 
             if (me->encryption == true && me->encryptiontype == ENC_AES128) {
                 decrypt_aes128(ms, &seg);

--- a/src/hls.h
+++ b/src/hls.h
@@ -22,6 +22,7 @@ extern "C" {
 #define HLSDL_MIN_REFRESH_DELAY_SEC    0
 #define HLSDL_MAX_REFRESH_DELAY_SEC    5
 #define HLSDL_LIVE_START_OFFSET_SEC  120
+#define HLSDL_LIVE_DURATION         (-1)
 #define HLSDL_MAX_RETRIES             30
 #define HLSDL_OPEN_MAX_RETRIES         3
 

--- a/src/main.c
+++ b/src/main.c
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
             int width, maxwidth = 0;
             int height, maxheight = 0;
             hls_media_playlist_t *me;
-	    for (me = master_playlist.media_playlist; me; me = me->next) {
+            for (me = master_playlist.media_playlist; me; me = me->next) {
                 if (sscanf(me->resolution, "%dx%d", &width, &height) < 2)
                     break;
                 if (width > hls_args.maxwidth && hls_args.maxwidth != -1)
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
             }
             if (selected == NULL) {
                 MSG_ERROR("No resolution match found\n");
-		exit(1);
+                exit(1);
             }
             MSG_VERBOSE("Choosing by resolution. (Bitrate: %d), (Resolution: %s), (Codecs: %s)\n", selected->bitrate, selected->resolution, selected->codecs);
         } else {

--- a/src/main.c
+++ b/src/main.c
@@ -128,6 +128,7 @@ int main(int argc, char *argv[])
     hls_args.loglevel = 0;
     hls_args.segment_download_retries = HLSDL_MAX_RETRIES;
     hls_args.live_start_offset_sec = HLSDL_LIVE_START_OFFSET_SEC;
+    hls_args.live_duration_sec = HLSDL_LIVE_DURATION;
     hls_args.open_max_retries = HLSDL_OPEN_MAX_RETRIES;
     hls_args.refresh_delay_sec = -1;
     hls_args.maxwidth = -1;

--- a/src/misc.c
+++ b/src/misc.c
@@ -40,6 +40,7 @@ static void print_help(const char *filename)
            "-d ... Print the openssl decryption command.\n"
            "-t ... Print the links to the .ts files.\n"
            "-s ... Set live start offset in seconds.\n"
+           "-i ... Set live stream download duration in seconds.\n"
            "-e ... Set refresh delay in seconds.\n"
            "-r ... Set max retries at open.\n"
            "-w ... Set max download segment retries.\n"
@@ -54,7 +55,7 @@ int parse_argv(int argc, char * const argv[])
     int ret = 0;
     int c = 0;
     int custom_header_idx = 0;
-    while ( (c = getopt(argc, argv, "bH:W:A:vqbfFK:ctdo:u:h:s:r:w:e:p:k:n:a:C:")) != -1)
+    while ( (c = getopt(argc, argv, "bH:W:A:vqbfFK:ctdo:u:h:s:i:r:w:e:p:k:n:a:C:")) != -1)
     {
         switch (c)
         {
@@ -97,6 +98,9 @@ int parse_argv(int argc, char * const argv[])
             break;
         case 's':
             hls_args.live_start_offset_sec = atoi(optarg);
+            break;
+        case 'i':
+            hls_args.live_duration_sec = atoi(optarg);
             break;
         case 'e':
             hls_args.refresh_delay_sec = atoi(optarg);

--- a/src/misc.h
+++ b/src/misc.h
@@ -38,6 +38,7 @@ struct hls_args {
     bool dump_ts_urls;
     bool dump_dec_cmd;
     int live_start_offset_sec;
+    int live_duration_sec;
     int refresh_delay_sec;
     int segment_download_retries;
     int open_max_retries;


### PR DESCRIPTION
The main commit in this PR is a new option -i seconds to set the duration of downloading in seconds, similar to how -s sets its starting time.

The other changes are minor.