### PR TITLE
BO fix

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -112,7 +112,10 @@ int parse_argv(int argc, char * const argv[])
             hls_args.segment_download_retries = atoi(optarg);
             break;
         case 'o':
-            hls_args.filename = optarg;
+	    if(strlen(optarg) < MAX_FILENAME_LEN)
+                hls_args.filename = optarg;
+            else
+		MSG_PRINT("Output filename is too long. Using default filename instead.\n");
             break;
         case 't':
             hls_args.dump_ts_urls = true;

--- a/src/misc.c
+++ b/src/misc.c
@@ -112,10 +112,10 @@ int parse_argv(int argc, char * const argv[])
             hls_args.segment_download_retries = atoi(optarg);
             break;
         case 'o':
-	    if(strlen(optarg) < MAX_FILENAME_LEN)
+            if(strlen(optarg) < MAX_FILENAME_LEN)
                 hls_args.filename = optarg;
             else
-		MSG_PRINT("Output filename is too long. Using default filename instead.\n");
+                MSG_PRINT("Output filename is too long. Using default filename instead.\n");
             break;
         case 't':
             hls_args.dump_ts_urls = true;


### PR DESCRIPTION
This pull request fixes a buffer overflow vulnerability with long output file names. Due to a static buffer an attacker could access and write protected memory.
The suggested code fixes this vulnerability by checking the length of the supplied name and using the default filename if the name is longer than the size of the buffer.