### PR TITLE
hls: check the length of the downloaded AES-128 key

### DIFF
--- a/src/hls.c
+++ b/src/hls.c
@@ -1770,7 +1770,7 @@ int fill_key_value(struct enc_aes128 *es)
                 free(key_url);
             }
 
-            if (http_code != 200 || size == 0) {
+            if (http_code != 200) {
                 MSG_ERROR("Getting key-file [%s] failed http_code[%d].\n", es->key_url, http_code);
                 return 1;
             }

--- a/src/hls.c
+++ b/src/hls.c
@@ -1775,6 +1775,11 @@ int fill_key_value(struct enc_aes128 *es)
                 return 1;
             }
 
+            if (size != KEYLEN) {
+                MSG_ERROR("Wrong length key-file. Expected %u bytes but got %u.\n", KEYLEN, size);
+                return 1;
+            }
+
             memcpy(es->key_value, key_value, KEYLEN);
             free(key_value);
 


### PR DESCRIPTION
Hello! Thank you for making this great project.

I'm from https://github.com/yt-dlp/yt-dlp/issues/2537#issuecomment-1256555973 . I tried to download a stream by **hlsdl** (this project) at that time but kept getting "```Error: AES128_CBC_DecryptUpdate failed: 0, in_size: ..., out_size: ...```".
After debugging, I found that the key was just 9 bytes. I didn't specify the correct HTTP header, and then the server replied with a HTTP 200 and a body with the string "```Forbidden```". It should reply with a failed status code, shouldn't it ;)

To make the error message a little more detailed in this case, I think we can check the key length after getting it. The length of the AES-128 key must be 16 bytes, so the logic is simple.

Also, the "```memcpy```" always copy 16 bytes data from "```key_value```" ([code](https://github.com/selsta/hlsdl/blob/883acbdb59ada7739f3ae75207bb74bac1994f75/src/hls.c#L1778)). If the key is shorter, it will read dirty data.

It's worth noting that the return value of the "[```int fill_key_value(struct enc_aes128 *)```](https://github.com/selsta/hlsdl/blob/883acbdb59ada7739f3ae75207bb74bac1994f75/src/hls.c#L1725)" function is ignored, so currently we are not able to stop the program when the key is wrong.

### Test

Before (883acbdb59ada7739f3ae75207bb74bac1994f75):

```console
$ ...
> START media_playlist_get_links
> END media_playlist_get_links
HLS Stream is AES-128 encrypted.
{"d_t":"live"}
Downloading part ...
Error: AES128_CBC_DecryptUpdate failed: 0, in_size: ..., out_size: ...
{"t_d":...,"d_d":...,"d_s":...}
Downloading part ...
Error: AES128_CBC_DecryptUpdate failed: 0, in_size: ..., out_size: ...
Downloading part ...

```

After (771a2a6510c7f74c060fef09d313d181e3bb352f):

```console
$ ...
> START media_playlist_get_links
> END media_playlist_get_links
HLS Stream is AES-128 encrypted.
{"d_t":"live"}
Downloading part ...
Error: Wrong length key-file. Expected 16 bytes but got 9.
Error: AES128_CBC_DecryptUpdate failed: 0, in_size: ..., out_size: ...
{"t_d":...,"d_d":...,"d_s":...}
Downloading part ...
Error: Wrong length key-file. Expected 16 bytes but got 9.
Error: AES128_CBC_DecryptUpdate failed: 0, in_size: ..., out_size: ...
Downloading part ...

```