### PR TITLE
Fixed the Segmentation fault error when non valid url is provided

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -121,6 +121,7 @@ static bool get_data_with_retry(char *url, char **hlsfile_source, char **finall_
 
     if (http_code != 200) {
         MSG_API("{\"error_code\":%d, \"error_msg\":\"\"}\n", (int)http_code);
+        return false;
     }
 
     if (size == 0) {


### PR DESCRIPTION
When a non valid is provided to hlsdl command line tool, Segmentation fault error is occurring.

Steps to reproduce:
```sh
hlsdl abcd
```

Output:
```sh
Error: No such file or directory
Error: abcd 404 tries[3]
Error: No such file or directory
Error: abcd 404 tries[2]
Error: No such file or directory
Error: abcd 404 tries[1]
{"error_code":404, "error_msg":""}
Segmentation fault (core dumped)
```


Fixed the code to handle the URL correctly and in result Segmentation fault is not occurring.

Output after fix:
```sh
Error: No such file or directory
Error: abcd 404 tries[3]
Error: No such file or directory
Error: abcd 404 tries[2]
Error: No such file or directory
Error: abcd 404 tries[1]
{"error_code":404, "error_msg":""}
```