### PR TITLE
Support for EXT-X-MAP (basic)

### DIFF
--- a/src/hls.h
+++ b/src/hls.h
@@ -39,6 +39,7 @@ typedef struct hls_media_segment {
     int64_t offset;
     int64_t size;
     int sequence_number;
+    bool is_map;
     uint64_t duration_ms;
     struct enc_aes128 enc_aes;
     struct hls_media_segment *next;


### PR DESCRIPTION
This adds basic support for the EXT-X-MAP tag that has the Media Initialization Section necessary for a valid video.
Things that don't work yet, probably:
- Discontinuities. When a new map comes, it would be written like any other segment, but probably should start a new file. Considering that hlsdl is only give one target file per launch, this would need some thinking.
- Encryption. I haven't quite understood form the spec how does an init section behave in the presence of encryption, and what must be used as the key.