### PR TITLE
Add debian packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ https://github.com/selsta/hlsdl/blob/master/msvc/BUID_WINDOWS.txt
 
 Docker: `docker build -t hlsdl:latest .`
 
+Build debian package: `make deb`
 
 Usage and Options
 -----------------
+
 `./hlsdl [options] url`
 
 ```
@@ -31,6 +33,7 @@ docker run -v ./data:/var/hlsdl/data --rm -it hlsdl:latest hlsdl [options] url
 ```
 
 ---------------------------
+
 ```
 -b ... Automatically choose the best quality.
 
@@ -85,6 +88,7 @@ docker run -v ./data:/var/hlsdl/data --rm -it hlsdl:latest hlsdl [options] url
 
 ToDo
 -----
+
 * support for Fragmented MPEG-4 playlist
 * support for EXT-X-MAP in the MPEG-2 Transport Streams playlist
 

--- a/makefile
+++ b/makefile
@@ -59,3 +59,44 @@ clean:
 	rm -f $(HLSDL)
 
 .PHONY: clean
+
+# Build debian package
+APP_BIN=./hlsdl
+PACKAGE_VERSION=$(patsubst v%,%,$(shell git describe --tags --long --dirty))
+PACKAGE_DEPS=$(patsubst shlibs:Depends=%,%,$(shell dpkg-shlibdeps ${APP_BIN} -O))
+PACKAGE_TYPE=deb
+PACKAGE_ARCH=$(shell dpkg --print-architecture)
+PACKAGE_NAME=hlsdl
+PACKAGE_FILENAME=${PACKAGE_NAME}-${PACKAGE_VERSION}-${PACKAGE_ARCH}.${PACKAGE_TYPE}
+PACKAGE_BINDIR=/usr/local/bin
+LINTIAN_IGNORE=debian-changelog-file-missing-or-wrong-name,dir-in-usr-local,extended-description-is-empty,file-in-usr-local
+
+deb: all
+
+ifeq (, $(shell which dpkg-shlibdeps))
+	$(error "dpkg-shlibdeps is required, consider doing apt-get install dpkg-dev")
+endif
+ifeq (, $(shell which fpm))
+	$(error "fpm is required, please check https://fpm.readthedocs.io/en/latest/installation.html")
+endif
+	strip -s  "${APP_BIN}"
+	chmod 755 "${APP_BIN}"
+	chmod 644 "LICENSE"
+	fpm -f -s dir                  \
+  -t             "${PACKAGE_TYPE}"     \
+  -p             "${PACKAGE_FILENAME}" \
+  --name         "${PACKAGE_NAME}"     \
+  --version      "${PACKAGE_VERSION}"  \
+  --architecture "${PACKAGE_ARCH}"     \
+  --depends      "${PACKAGE_DEPS}"     \
+  --description "Converts .m3u8 playlists (using fragmented mpegts) to a .ts video." \
+  --url         "https://github.com/selsta/hlsdl"       \
+  --maintainer  "selsta <selsta@sent.at>"               \
+  --license     "MIT"                                   \
+    "LICENSE"="usr/share/doc/${PACKAGE_NAME}/copyright" \
+    ${APP_BIN}="${PACKAGE_BINDIR}/${PACKAGE_NAME}"
+ifeq (, $(shell which lintian))
+	@echo "warning: lintian is not available: package checking is disabled, consider doing apt-get install lintian"
+else
+	lintian --suppress-tags "${LINTIAN_IGNORE}" "${PACKAGE_FILENAME}"
+endif


### PR DESCRIPTION
Build a .deb
To get a proper package version, this proposal is to derive the version on a git tag of the form v<XXX>.
So, for example, to begin with:
>git tag v1.0
Then:
>make deb